### PR TITLE
add project auto-assigner feature

### DIFF
--- a/.github/virtual-assistant.yml
+++ b/.github/virtual-assistant.yml
@@ -22,3 +22,11 @@ labeler:
       - opened
       - synchronize
 
+assigner:
+  issues:
+    project:
+      id: 1
+      column: To Do
+    actions:
+      - opened
+      - milestoned

--- a/pkg/actions/assigner/assigner.go
+++ b/pkg/actions/assigner/assigner.go
@@ -1,0 +1,54 @@
+package assigner
+
+import (
+	gh "github.com/google/go-github/v27/github"
+
+	"github.com/ppapapetrou76/virtual-assistant/pkg/actions"
+	"github.com/ppapapetrou76/virtual-assistant/pkg/config"
+	"github.com/ppapapetrou76/virtual-assistant/pkg/github"
+)
+
+// Assigner is the struct to handle auto-assigning issues and pull-requests
+type Assigner struct {
+	*config.AssignerConfig
+	github.Repo
+}
+
+// HandleEvent takes a GitHub Event and its raw payload (see link below)
+// to trigger an update to the issue / PR's labels.
+//
+// https://developer.github.com/v3/activity/events/types/
+func (l *Assigner) HandleEvent(eventName string, payload *[]byte) error {
+	event, err := gh.ParseWebHook(eventName, *payload)
+	if err != nil {
+		return err
+	}
+	switch event := event.(type) {
+	case *gh.PullRequestEvent:
+		// Todo : Implement pull request event handler
+	case *gh.IssuesEvent:
+		if actions.ShouldRunOnIssue(event, l.IssuesAssignerConfig.Actions) {
+			err = l.runOnIssue(event.Issue)
+		}
+	}
+	return err
+}
+
+func (l *Assigner) runOnIssue(i *gh.Issue) error {
+	issue := github.NewIssue(l.Repo, *i.Number)
+	err := issue.AddToProject(l.AssignerConfig.ProjectID, l.AssignerConfig.Column)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// New creates a new labeler object
+func New(c *config.Config, repo github.Repo) *Assigner {
+	return &Assigner{
+		AssignerConfig: &c.AssignerConfig,
+		Repo:           repo,
+	}
+}

--- a/pkg/actions/assigner/assigner_test.go
+++ b/pkg/actions/assigner/assigner_test.go
@@ -1,0 +1,112 @@
+package assigner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ppapapetrou76/virtual-assistant/pkg/config"
+	"github.com/ppapapetrou76/virtual-assistant/pkg/github"
+	"github.com/ppapapetrou76/virtual-assistant/pkg/testutil"
+)
+
+const webhookIssuePayload = `
+{
+  "action": "opened",
+  "issue": {
+    "id": 444500041,
+    "node_id": "MDU6SXNzdWU0NDQ1MDAwNDE=",
+    "number": 1,
+    "title": "Some random issue"
+  }
+}`
+
+func TestAssigner_HandleEvent(t *testing.T) {
+	type fields struct {
+		repo github.Repo
+	}
+	type args struct {
+		labels    []string
+		payload   []byte
+		eventName string
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		wantErr       bool
+		expectedError error
+	}{
+		{
+			name: "should handle an issue event",
+			args: args{
+				labels:    []string{"bug", "enhancement"},
+				payload:   []byte(webhookIssuePayload),
+				eventName: "issues",
+			},
+			fields: fields{
+				repo: github.Repo{
+					GHClient: github.MockGithubClient([]github.MockResponse{
+						github.MockGetIssueResponse(),
+						github.MockListProjectColumnsResponse(),
+						github.MockGenericSuccessResponse(),
+					}),
+				},
+			},
+		},
+		{
+			name: "should return error if event is issue and fetching current label fails",
+			args: args{
+				labels:    []string{"bug", "enhancement"},
+				payload:   []byte(webhookIssuePayload),
+				eventName: "issues",
+			},
+			fields: fields{
+				repo: github.Repo{
+					GHClient: github.MockGithubClient([]github.MockResponse{
+						github.UnAuthorizedMockResponse(),
+					}),
+					Owner: "ppapapetrou76",
+					Name:  "virtual-assistant",
+				},
+			},
+			wantErr:       true,
+			expectedError: errors.New("cannot get issue with number 1. error message : GET https://api.github.com/repos/ppapapetrou76/virtual-assistant/issues/1: 401 Bad credentials []"),
+		},
+		{
+			name: "should return error parsing webhook",
+			args: args{
+				labels:    []string{"bug", "enhancement"},
+				payload:   []byte("random payload"),
+				eventName: "pull_request",
+			},
+			fields: fields{
+
+				repo: github.Repo{
+					GHClient: github.MockGithubClient([]github.MockResponse{github.MockGenericSuccessResponse()}),
+					Owner:    "ppapapetrou76",
+					Name:     "virtual-assistant",
+				},
+			},
+			wantErr:       true,
+			expectedError: errors.New("invalid character 'r' looking for beginning of value"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assigner := Assigner{
+				AssignerConfig: &config.AssignerConfig{
+					IssuesAssignerConfig: config.IssuesAssignerConfig{
+						IssuesAssignerProjectConfig: config.IssuesAssignerProjectConfig{
+							ProjectID: 1,
+							Column:    "To Do",
+						},
+						Actions: []string{"opened"},
+					},
+				},
+				Repo: tt.fields.repo,
+			}
+			err := assigner.HandleEvent(tt.args.eventName, &tt.args.payload)
+			testutil.AssertError(t, tt.wantErr, tt.expectedError, err)
+		})
+	}
+}

--- a/pkg/actions/common.go
+++ b/pkg/actions/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ppapapetrou76/virtual-assistant/pkg/util/slices"
 )
 
+// ShouldRunOnIssue returns true if the action should run on a given issues event and user defined actions
 func ShouldRunOnIssue(event *github.IssuesEvent, configuredActions slices.StringSlice) bool {
 	if addDefaultIfEmpty(configuredActions).HasString(*event.Action) {
 		return true
@@ -16,6 +17,7 @@ func ShouldRunOnIssue(event *github.IssuesEvent, configuredActions slices.String
 	return false
 }
 
+// ShouldRunOnPullRequest returns true if the action should run on a given pull request event and user defined actions
 func ShouldRunOnPullRequest(event *github.PullRequestEvent, configuredActions slices.StringSlice) bool {
 	if addDefaultIfEmpty(configuredActions).HasString(*event.Action) {
 		return true

--- a/pkg/actions/common.go
+++ b/pkg/actions/common.go
@@ -1,0 +1,33 @@
+package actions
+
+import (
+	"log"
+
+	"github.com/google/go-github/v27/github"
+
+	"github.com/ppapapetrou76/virtual-assistant/pkg/util/slices"
+)
+
+func ShouldRunOnIssue(event *github.IssuesEvent, configuredActions slices.StringSlice) bool {
+	if addDefaultIfEmpty(configuredActions).HasString(*event.Action) {
+		return true
+	}
+	log.Printf("Issues event is `%s` - eligible actions are `%v`. Skipping issues labeler", *event.Action, configuredActions)
+	return false
+}
+
+func ShouldRunOnPullRequest(event *github.PullRequestEvent, configuredActions slices.StringSlice) bool {
+	if addDefaultIfEmpty(configuredActions).HasString(*event.Action) {
+		return true
+	}
+	log.Printf("Pull request event is `%s` - eligible actions are `%v`. Skipping issues labeler", *event.Action, configuredActions)
+	return false
+}
+
+func addDefaultIfEmpty(actions slices.StringSlice) slices.StringSlice {
+	if actions.IsEmpty() {
+		return actions.Add("opened")
+	}
+
+	return actions
+}

--- a/pkg/actions/common_test.go
+++ b/pkg/actions/common_test.go
@@ -1,0 +1,110 @@
+package actions
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/v27/github"
+
+	"github.com/ppapapetrou76/virtual-assistant/pkg/util/slices"
+)
+
+func TestShouldRunOnIssue(t *testing.T) {
+	opened := "opened"
+	type args struct {
+		event             *github.IssuesEvent
+		configuredActions slices.StringSlice
+	}
+	tests := []struct {
+		name     string
+		expected bool
+		args     args
+	}{
+		{
+			name:     "should return true",
+			expected: true,
+			args: args{
+				event: &github.IssuesEvent{
+					Action: &opened,
+				},
+				configuredActions: []string{"opened", "closed"},
+			},
+		},
+		{
+			name:     "should use the default values and return true",
+			expected: true,
+			args: args{
+				event: &github.IssuesEvent{
+					Action: &opened,
+				},
+			},
+		},
+		{
+			name: "should return false",
+			args: args{
+				event: &github.IssuesEvent{
+					Action: &opened,
+				},
+				configuredActions: []string{"closed"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ShouldRunOnIssue(tt.args.event, tt.args.configuredActions)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("Expect: \n%+v Got: \n%+v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestShouldRunOnPullRequest(t *testing.T) {
+	opened := "opened"
+	type args struct {
+		event             *github.PullRequestEvent
+		configuredActions slices.StringSlice
+	}
+	tests := []struct {
+		name     string
+		expected bool
+		args     args
+	}{
+		{
+			name:     "should return true",
+			expected: true,
+			args: args{
+				event: &github.PullRequestEvent{
+					Action: &opened,
+				},
+				configuredActions: []string{"opened", "closed"},
+			},
+		},
+		{
+			name:     "should use the default values and return true",
+			expected: true,
+			args: args{
+				event: &github.PullRequestEvent{
+					Action: &opened,
+				},
+			},
+		},
+		{
+			name: "should return false",
+			args: args{
+				event: &github.PullRequestEvent{
+					Action: &opened,
+				},
+				configuredActions: []string{"closed"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ShouldRunOnPullRequest(tt.args.event, tt.args.configuredActions)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("Expect: \n%+v Got: \n%+v", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/actions/labeler/labeler_test.go
+++ b/pkg/actions/labeler/labeler_test.go
@@ -59,11 +59,14 @@ func TestLabeler_HandleEvent(t *testing.T) {
 				eventName: "pull_request",
 			},
 			fields: fields{
-
 				repo: github.Repo{
-					GHClient: github.MockGithubClient(200, ""),
-					Owner:    "ppapapetrou76",
-					Name:     "virtual-assistant",
+					GHClient: github.MockGithubClient([]github.MockResponse{
+						github.MockGenericSuccessResponse(),
+						github.MockGenericSuccessResponse(),
+						github.MockGenericSuccessResponse(),
+					}),
+					Owner: "ppapapetrou76",
+					Name:  "virtual-assistant",
 				},
 			},
 		},
@@ -75,11 +78,14 @@ func TestLabeler_HandleEvent(t *testing.T) {
 				eventName: "issues",
 			},
 			fields: fields{
-
 				repo: github.Repo{
-					GHClient: github.MockGithubClient(200, ""),
-					Owner:    "ppapapetrou76",
-					Name:     "virtual-assistant",
+					GHClient: github.MockGithubClient([]github.MockResponse{
+						github.MockGenericSuccessResponse(),
+						github.MockGenericSuccessResponse(),
+						github.MockGenericSuccessResponse(),
+					}),
+					Owner: "ppapapetrou76",
+					Name:  "virtual-assistant",
 				},
 			},
 		},
@@ -92,10 +98,9 @@ func TestLabeler_HandleEvent(t *testing.T) {
 			},
 			fields: fields{
 				repo: github.Repo{
-					GHClient: github.MockGithubClient(401, `{
-						  "message": "Bad credentials",
-						  "documentation_url": "https://developer.github.com/v3"
-						}`),
+					GHClient: github.MockGithubClient([]github.MockResponse{
+						github.UnAuthorizedMockResponse(),
+					}),
 					Owner: "ppapapetrou76",
 					Name:  "virtual-assistant",
 				},
@@ -112,10 +117,9 @@ func TestLabeler_HandleEvent(t *testing.T) {
 			},
 			fields: fields{
 				repo: github.Repo{
-					GHClient: github.MockGithubClient(401, `{
-						  "message": "Bad credentials",
-						  "documentation_url": "https://developer.github.com/v3"
-						}`),
+					GHClient: github.MockGithubClient([]github.MockResponse{
+						github.UnAuthorizedMockResponse(),
+					}),
 					Owner: "ppapapetrou76",
 					Name:  "virtual-assistant",
 				},
@@ -131,9 +135,8 @@ func TestLabeler_HandleEvent(t *testing.T) {
 				eventName: "pull_request",
 			},
 			fields: fields{
-
 				repo: github.Repo{
-					GHClient: github.MockGithubClient(200, ""),
+					GHClient: github.MockGithubClient([]github.MockResponse{github.MockGenericSuccessResponse()}),
 					Owner:    "ppapapetrou76",
 					Name:     "virtual-assistant",
 				},
@@ -145,14 +148,12 @@ func TestLabeler_HandleEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			labeler := Labeler{
-				Config: &config.Config{
-					LabelerConfig: config.LabelerConfig{
-						PullRequestsLabelerConfig: config.PullRequestsLabelerConfig{
-							Labels: []string{"bug"},
-						},
-						IssuesLabelerConfig: config.IssuesLabelerConfig{
-							Labels: []string{"feature"},
-						},
+				LabelerConfig: &config.LabelerConfig{
+					PullRequestsLabelerConfig: config.PullRequestsLabelerConfig{
+						Labels: []string{"bug"},
+					},
+					IssuesLabelerConfig: config.IssuesLabelerConfig{
+						Labels: []string{"feature"},
 					},
 				},
 				Repo: tt.fields.repo,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,16 +11,17 @@ import (
 
 // Config is the struct to hold user configuration
 type Config struct {
-	LabelerConfig `yaml:"labeler"`
+	LabelerConfig  `yaml:"labeler"`
+	AssignerConfig `yaml:"assigner"`
 }
 
-// LabelerConfig is the struct to hold user configuration
+// LabelerConfig is the struct to hold user configuration for the labeler
 type LabelerConfig struct {
 	IssuesLabelerConfig       `yaml:"issues"`
 	PullRequestsLabelerConfig `yaml:"pull-requests"`
 }
 
-// IssuesLabelerConfig is the struct to hold user configuration related to issues
+// IssuesLabelerConfig is the struct to hold user configuration related to issues labeler
 type IssuesLabelerConfig struct {
 	Labels     slices.StringSlice
 	Actions    slices.StringSlice
@@ -34,10 +35,27 @@ type OneOfaKind struct {
 	Default        string
 }
 
-// PullRequestsLabelerConfig is the struct to hold user configuration related to pull-requests
+// PullRequestsLabelerConfig is the struct to hold user configuration related to pull-requests labeler
 type PullRequestsLabelerConfig struct {
 	Labels  slices.StringSlice
 	Actions slices.StringSlice
+}
+
+// AssignerConfig is the struct to hold user configuration for the assigner
+type AssignerConfig struct {
+	IssuesAssignerConfig `yaml:"issues"`
+}
+
+// IssuesLabelerConfig is the struct to hold user configuration related to issues labeler
+type IssuesAssignerConfig struct {
+	IssuesAssignerProjectConfig `yaml:"project"`
+	Actions                     slices.StringSlice
+}
+
+// IssuesLabelerConfig is the struct to hold user configuration related to issues labeler
+type IssuesAssignerProjectConfig struct {
+	ProjectID int64  `yaml:"id"`
+	Column    string `yaml:"column"`
 }
 
 // Load loads config data from raw format to a Config struct

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,13 +46,13 @@ type AssignerConfig struct {
 	IssuesAssignerConfig `yaml:"issues"`
 }
 
-// IssuesLabelerConfig is the struct to hold user configuration related to issues labeler
+// IssuesAssignerConfig is the struct to hold user configuration related to issues labeler
 type IssuesAssignerConfig struct {
 	IssuesAssignerProjectConfig `yaml:"project"`
 	Actions                     slices.StringSlice
 }
 
-// IssuesLabelerConfig is the struct to hold user configuration related to issues labeler
+// IssuesAssignerProjectConfig is the struct to hold user configuration related to issues labeler
 type IssuesAssignerProjectConfig struct {
 	ProjectID int64  `yaml:"id"`
 	Column    string `yaml:"column"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -33,6 +33,18 @@ func TestLoad(t *testing.T) {
 				fileName: "../../test_data/valid-config.yml",
 			},
 			expected: &Config{
+				AssignerConfig: AssignerConfig{
+					IssuesAssignerConfig: IssuesAssignerConfig{
+						Actions: []string{
+							"opened",
+							"milestoned",
+						},
+						IssuesAssignerProjectConfig: IssuesAssignerProjectConfig{
+							ProjectID: 1,
+							Column:    "To Do",
+						},
+					},
+				},
 				LabelerConfig: LabelerConfig{
 					IssuesLabelerConfig: IssuesLabelerConfig{
 						Labels: []string{

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -47,6 +47,7 @@ const listIssueLabelsResponse = `[
   }
 ]`
 
+// MockResponse mocks an http response
 type MockResponse struct {
 	StatusCode int
 	Response   string
@@ -93,6 +94,7 @@ func (m *MockRoundTripper) nextResponse() MockResponse {
 	return r
 }
 
+// UnAuthorizedMockResponse returns a mock response with a 401 error code and message
 func UnAuthorizedMockResponse() MockResponse {
 	return MockResponse{
 		StatusCode: http.StatusUnauthorized,
@@ -103,6 +105,7 @@ func UnAuthorizedMockResponse() MockResponse {
 	}
 }
 
+// MockListIssueLabelsResponse returns a mock response for the list issue labels call
 func MockListIssueLabelsResponse() MockResponse {
 	return MockResponse{
 		StatusCode: http.StatusOK,
@@ -110,6 +113,7 @@ func MockListIssueLabelsResponse() MockResponse {
 	}
 }
 
+// MockGetIssueResponse returns a mock response for the get issue call
 func MockGetIssueResponse() MockResponse {
 	return MockResponse{
 		StatusCode: http.StatusOK,
@@ -117,6 +121,7 @@ func MockGetIssueResponse() MockResponse {
 	}
 }
 
+// MockListProjectColumnsResponse returns a mock response for the list project columns call
 func MockListProjectColumnsResponse() MockResponse {
 	return MockResponse{
 		StatusCode: http.StatusOK,
@@ -124,6 +129,7 @@ func MockListProjectColumnsResponse() MockResponse {
 	}
 }
 
+// MockGenericSuccessResponse returns a generic success mock response
 func MockGenericSuccessResponse() MockResponse {
 	return MockResponse{
 		StatusCode: http.StatusOK,

--- a/pkg/github/mock.go
+++ b/pkg/github/mock.go
@@ -6,17 +6,64 @@ import (
 	"net/http"
 )
 
-// MockRoundTripper mocks a RoundTripper
-type MockRoundTripper struct {
+const getIssueResponse = `{
+  "id": 1,
+  "node_id": "MDU6SXNzdWUx",
+  "number": 1347,
+  "state": "open",
+  "title": "Found a bug",
+  "body": "I'm having a problem with this."
+}
+`
+const listProjectColumnsResponse = `[
+  {
+    "url": "https://api.github.com/projects/columns/367",
+    "project_url": "https://api.github.com/projects/120",
+    "cards_url": "https://api.github.com/projects/columns/367/cards",
+    "id": 367,
+    "node_id": "MDEzOlByb2plY3RDb2x1bW4zNjc=",
+    "name": "To Do",
+    "created_at": "2016-09-05T14:18:44Z",
+    "updated_at": "2016-09-05T14:22:28Z"
+  }
+]`
+
+const listIssueLabelsResponse = `[
+  {
+    "id": 208045946,
+    "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+    "name": "bug",
+    "description": "Something isn't working",
+    "color": "f29513",
+    "default": true
+  },
+  {
+    "id": 208045947,
+    "node_id": "MDU6TGFiZWwyMDgwNDU5NDc=",
+    "name": "enhancement",
+    "description": "New feature or request",
+    "color": "a2eeef",
+    "default": false
+  }
+]`
+
+type MockResponse struct {
 	StatusCode int
 	Response   string
 }
 
+// MockRoundTripper mocks a RoundTripper
+type MockRoundTripper struct {
+	Responses         []MockResponse
+	nextResponseIndex int
+}
+
 // RoundTrip implements the RoundTripper interface
-func (m MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := m.nextResponse()
 	return &http.Response{
-		StatusCode: m.StatusCode,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(m.Response)),
+		StatusCode: r.StatusCode,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(r.Response)),
 		Header:     make(http.Header),
 		Request:    req,
 	}, nil
@@ -30,9 +77,55 @@ func NewTestClient(fn http.RoundTripper) *http.Client {
 }
 
 // MockGithubClient returns a mocked Github client for testing purposes
-func MockGithubClient(statusCode int, response string) ClientWrapper {
-	return Client(NewTestClient(MockRoundTripper{
-		StatusCode: statusCode,
-		Response:   response,
+func MockGithubClient(responses []MockResponse) ClientWrapper {
+	return Client(NewTestClient(&MockRoundTripper{
+		Responses: responses,
 	}))
+}
+
+func (m *MockRoundTripper) nextResponse() MockResponse {
+	if m.nextResponseIndex >= len(m.Responses) {
+		panic("no more responses mocked. please add more and re-run the test")
+	}
+
+	r := m.Responses[m.nextResponseIndex]
+	m.nextResponseIndex++
+	return r
+}
+
+func UnAuthorizedMockResponse() MockResponse {
+	return MockResponse{
+		StatusCode: http.StatusUnauthorized,
+		Response: `{
+					  "message": "Bad credentials",
+  		 			  "documentation_url": "https://developer.github.com/v3"
+				   }`,
+	}
+}
+
+func MockListIssueLabelsResponse() MockResponse {
+	return MockResponse{
+		StatusCode: http.StatusOK,
+		Response:   listIssueLabelsResponse,
+	}
+}
+
+func MockGetIssueResponse() MockResponse {
+	return MockResponse{
+		StatusCode: http.StatusOK,
+		Response:   getIssueResponse,
+	}
+}
+
+func MockListProjectColumnsResponse() MockResponse {
+	return MockResponse{
+		StatusCode: http.StatusOK,
+		Response:   listProjectColumnsResponse,
+	}
+}
+
+func MockGenericSuccessResponse() MockResponse {
+	return MockResponse{
+		StatusCode: http.StatusOK,
+	}
 }

--- a/pkg/github/repo_test.go
+++ b/pkg/github/repo_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"errors"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
@@ -73,14 +74,24 @@ func TestRepo_LoadFile(t *testing.T) {
 		{
 			name: "should return the file contents",
 			fields: fields{
-				ghClient: MockGithubClient(200, getContentResponse),
+				ghClient: MockGithubClient([]MockResponse{
+					{
+						StatusCode: http.StatusOK,
+						Response:   getContentResponse,
+					},
+				}),
 			},
 			expectedContents: []byte("I'm a secret"),
 		},
 		{
 			name: "should error if file cannot be loaded",
 			fields: fields{
-				ghClient: MockGithubClient(200, "ok"),
+				ghClient: MockGithubClient([]MockResponse{
+					{
+						StatusCode: http.StatusOK,
+						Response:   "ok",
+					},
+				}),
 			},
 			expectedError: errors.New("load file : unable to load file from ppapapetrou76/virtual-assistant@/some-file: invalid character 'o' looking for beginning of value"),
 			wantErr:       true,

--- a/test_data/valid-config.yml
+++ b/test_data/valid-config.yml
@@ -1,24 +1,32 @@
 labeler:
-      issues:
-            labels:
-                  - label1
-                  - label2
-                  - area:label3
-            actions:
-                  - opened
-                  - milestoned
-            at-least-one:
-                  labels:
-                        - priority:1
-                        - priority:2
-                        - priority:3
-                  default: priority:2
+  issues:
+    labels:
+      - label1
+      - label2
+      - area:label3
+    actions:
+      - opened
+      - milestoned
+    at-least-one:
+      labels:
+        - priority:1
+        - priority:2
+        - priority:3
+      default: priority:2
 
-      pull-requests:
-            labels:
-                  - label1
-                  - label2
-            actions:
-                  - opened
-                  - synchronize
+  pull-requests:
+    labels:
+      - label1
+      - label2
+    actions:
+      - opened
+      - synchronize
 
+assigner:
+  issues:
+    project:
+      id: 1
+      column: To Do
+    actions:
+      - opened
+      - milestoned


### PR DESCRIPTION
- refactors the existing config to accommodate the new feature
- refactors code and moves it to common packages for re-usability
- moves actions to their own folder(s)
- refactors github mocking to support multiple responses
- adds a new feature to auto-assign a feature to a project

Closes #13 